### PR TITLE
Combine blocks and heap arrays

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv) {
 	print_blocks();
 
 	// Allocate the entire heap
-	char *ptr9 = alloc(65536);
+	char *ptr9 = alloc(65536 - 2 * 16); // 2 * 16 bytes of space needed for the ptr9 and ptr10 blocks
 	print_blocks();
 
 	// Try allocate a single additional byte


### PR DESCRIPTION
Blocks are now stored in reverse order at the end of the heap array.
The BLOCK_CAPACITY definition is no longer needed, opening up the possibility for client-specified heap sizes.
Closes #1.